### PR TITLE
Namespacing fix for colcon build errors

### DIFF
--- a/include/seatrac_driver/SeatracEnums.h
+++ b/include/seatrac_driver/SeatracEnums.h
@@ -638,8 +638,7 @@ enum ACOFIX_FLAGS : uint8_t {
     RANGE_VALID = 0x01,         // If this bit is set, it indicates the record contains the Range fields
 };
 
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os, narval::seatrac::BAUDRATE_E rate)
 {
@@ -877,5 +876,8 @@ inline std::ostream& operator<<(std::ostream& os, narval::seatrac::NAV_QUERY_E f
         os << "None";
     return os;
 }
+
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_SEATRAC_ENUMS_H_

--- a/include/seatrac_driver/SeatracTypes.h
+++ b/include/seatrac_driver/SeatracTypes.h
@@ -648,8 +648,7 @@ struct SETTINGS_T {
                             // fix.
 }__attribute__((packed));
 
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::ACOFIXRANGE_T& msg)
@@ -834,5 +833,8 @@ inline std::ostream& operator<<(std::ostream& os, const narval::seatrac::SETTING
        << prefix << "xcvrPosfltTmo  : " << (int)settings.xcvrPosfltTmo;
     return os;
 }
+
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_SEATRAC_TYPES_H_

--- a/include/seatrac_driver/messages/DataError.h
+++ b/include/seatrac_driver/messages/DataError.h
@@ -13,9 +13,7 @@ struct DataError : public Message<DataError> {
     BID_E beaconId;
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::DataError& msg)
@@ -25,5 +23,9 @@ inline std::ostream& operator<<(std::ostream& os,
        << "- status (error type): " << msg.status;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_DATA_ERROR_H_

--- a/include/seatrac_driver/messages/DataQueueSet.h
+++ b/include/seatrac_driver/messages/DataQueueSet.h
@@ -25,9 +25,7 @@ struct DataQueueSet : public Message<DataQueueSet> {
 
 } __attribute__((packed));
 
-}; // namespace messages
-}; // namespace seatrac
-}; // namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::DataQueueSet::Request& msg)
@@ -59,5 +57,9 @@ inline std::ostream& operator<<(std::ostream& os,
        << "- beaconId: " << msg.beaconId << std::endl;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif // _DEF_SEATRAC_DRIVER_MESSAGES_DATA_QUEUE_SET_H_

--- a/include/seatrac_driver/messages/DataReceive.h
+++ b/include/seatrac_driver/messages/DataReceive.h
@@ -44,9 +44,7 @@ struct DataReceive : public Message<DataReceive>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::DataReceive& msg)
@@ -70,6 +68,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "\nLocal Flag: " << (msg.localFlag ? "True":"False");
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_DATA_RECEIVE_H_
 

--- a/include/seatrac_driver/messages/DataSend.h
+++ b/include/seatrac_driver/messages/DataSend.h
@@ -24,9 +24,7 @@ struct DataSend : public Message<DataSend> {
 
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::DataSend::Request& msg)
@@ -59,5 +57,9 @@ inline std::ostream& operator<<(std::ostream& os,
     return os;
 }
 
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_DATA_SEND_H_

--- a/include/seatrac_driver/messages/EchoError.h
+++ b/include/seatrac_driver/messages/EchoError.h
@@ -13,9 +13,7 @@ struct EchoError : public Message<EchoError> {
     BID_E beaconId;
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::EchoError& msg)
@@ -25,5 +23,9 @@ inline std::ostream& operator<<(std::ostream& os,
        << "- status (error type): " << msg.status;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_ECHO_ERROR_H_

--- a/include/seatrac_driver/messages/EchoReq.h
+++ b/include/seatrac_driver/messages/EchoReq.h
@@ -31,9 +31,7 @@ struct EchoReq : public Message<EchoReq>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::EchoReq& msg)
@@ -55,6 +53,10 @@ inline std::ostream& operator<<(std::ostream& os,
     }
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_ECHO_REQ_H_
 

--- a/include/seatrac_driver/messages/EchoResp.h
+++ b/include/seatrac_driver/messages/EchoResp.h
@@ -31,9 +31,7 @@ struct EchoResp : public Message<EchoResp>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::EchoResp& msg)
@@ -55,6 +53,10 @@ inline std::ostream& operator<<(std::ostream& os,
     }
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_ECHO_RESP_H_
 

--- a/include/seatrac_driver/messages/EchoSend.h
+++ b/include/seatrac_driver/messages/EchoSend.h
@@ -24,9 +24,7 @@ struct EchoSend : public Message<EchoSend> {
 
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::EchoSend::Request& msg)
@@ -59,5 +57,9 @@ inline std::ostream& operator<<(std::ostream& os,
     return os;
 }
 
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_ECHO_SEND_H_

--- a/include/seatrac_driver/messages/MessageBase.h
+++ b/include/seatrac_driver/messages/MessageBase.h
@@ -36,9 +36,7 @@ struct Message
     }
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const narval::seatrac::messages::Message<T>& msg)
@@ -46,6 +44,10 @@ std::ostream& operator<<(std::ostream& os, const narval::seatrac::messages::Mess
     os << "Message :\n- msgId : " << msg.msgId;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_MESSAGE_BASE_H_
 

--- a/include/seatrac_driver/messages/NavError.h
+++ b/include/seatrac_driver/messages/NavError.h
@@ -17,9 +17,7 @@ struct NavError : public Message<NavError>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::NavError& msg)
@@ -27,6 +25,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "NavError (" << msg.beaconId << ") : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_NAV_ERROR_H_
 

--- a/include/seatrac_driver/messages/NavQueryReq.h
+++ b/include/seatrac_driver/messages/NavQueryReq.h
@@ -36,9 +36,7 @@ struct NavQueryReq : public Message<NavQueryReq>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::NavQueryReq& msg)
@@ -62,6 +60,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "\nLocal Flag: " << (msg.localFlag ? "True":"False");
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_NAV_QUERY_REQ_H_
 

--- a/include/seatrac_driver/messages/NavQueryResp.h
+++ b/include/seatrac_driver/messages/NavQueryResp.h
@@ -70,9 +70,7 @@ struct NavQueryResp : public Message<NavQueryResp>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::NavQueryResp& msg)
@@ -114,6 +112,10 @@ inline std::ostream& operator<<(std::ostream& os,
     else os << "\n- packet data: no data";
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_NAV_QUERY_RESP_H_
 

--- a/include/seatrac_driver/messages/NavQuerySend.h
+++ b/include/seatrac_driver/messages/NavQuerySend.h
@@ -24,9 +24,7 @@ struct NavQuerySend : public Message<NavQuerySend> {
 
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::NavQuerySend::Request& msg)
@@ -59,5 +57,9 @@ inline std::ostream& operator<<(std::ostream& os,
     return os;
 }
 
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_NAV_QUERY_SEND_H_

--- a/include/seatrac_driver/messages/PingError.h
+++ b/include/seatrac_driver/messages/PingError.h
@@ -17,9 +17,7 @@ struct PingError : public Message<PingError>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::PingError& msg)
@@ -27,6 +25,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "PingError (" << msg.beaconId << ") : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_PING_ERROR_H_
 

--- a/include/seatrac_driver/messages/PingReq.h
+++ b/include/seatrac_driver/messages/PingReq.h
@@ -22,9 +22,7 @@ struct PingReq : public Message<PingReq>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::PingReq& msg)
@@ -34,6 +32,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "PingReq";
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_PING_REQ_H_
 

--- a/include/seatrac_driver/messages/PingResp.h
+++ b/include/seatrac_driver/messages/PingResp.h
@@ -22,9 +22,7 @@ struct PingResp : public Message<PingResp>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::PingResp& msg)
@@ -32,6 +30,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "PingResp : " << msg.acoFix;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_PING_RESP_H_
 

--- a/include/seatrac_driver/messages/PingSend.h
+++ b/include/seatrac_driver/messages/PingSend.h
@@ -23,9 +23,7 @@ struct PingSend : public Message<PingSend>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::PingSend& msg)
@@ -33,6 +31,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "PingSend : " << msg.statusCode << ", target : " << msg.target;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_PING_SEND_H_
 

--- a/include/seatrac_driver/messages/SettingsGet.h
+++ b/include/seatrac_driver/messages/SettingsGet.h
@@ -20,9 +20,7 @@ struct SettingsGet : public Message<SettingsGet>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SettingsGet& msg)
@@ -33,6 +31,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "settings : " << print_utils::indent(msg.settings);
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SETTINGS_GET_H_
 

--- a/include/seatrac_driver/messages/SettingsLoad.h
+++ b/include/seatrac_driver/messages/SettingsLoad.h
@@ -20,9 +20,7 @@ struct SettingsLoad : public Message<SettingsLoad>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SettingsLoad& msg)
@@ -30,6 +28,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "SettingsLoad : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SETTINGS_LOAD_H_
 

--- a/include/seatrac_driver/messages/SettingsReset.h
+++ b/include/seatrac_driver/messages/SettingsReset.h
@@ -20,9 +20,7 @@ struct SettingsReset : public Message<SettingsReset>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SettingsReset& msg)
@@ -30,6 +28,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "SettingsReset : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SETTINGS_RESET_H_
 

--- a/include/seatrac_driver/messages/SettingsSave.h
+++ b/include/seatrac_driver/messages/SettingsSave.h
@@ -20,9 +20,7 @@ struct SettingsSave : public Message<SettingsSave>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SettingsSave& msg)
@@ -30,6 +28,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "SettingsSave : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SETTINGS_SAVE_H_
 

--- a/include/seatrac_driver/messages/SettingsSet.h
+++ b/include/seatrac_driver/messages/SettingsSet.h
@@ -20,9 +20,7 @@ struct SettingsSet : public Message<SettingsSet>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SettingsSet& msg)
@@ -30,6 +28,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "SettingsSet : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SETTINGS_SET_H_
 

--- a/include/seatrac_driver/messages/Status.h
+++ b/include/seatrac_driver/messages/Status.h
@@ -301,9 +301,7 @@ struct Status : public Message<Status>
     }
 }__attribute__((packed));
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::StatusEnvironment& msg)
@@ -439,5 +437,9 @@ inline std::ostream& operator<<(std::ostream& os, const narval::seatrac::message
 
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_STATUS_H_

--- a/include/seatrac_driver/messages/StatusConfigGet.h
+++ b/include/seatrac_driver/messages/StatusConfigGet.h
@@ -21,9 +21,7 @@ struct StatusConfigGet : public Message<StatusConfigGet>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::StatusConfigGet& msg)
@@ -35,6 +33,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "statusMode   : " << msg.statusMode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_STATUSCONFIGGET_H_
 

--- a/include/seatrac_driver/messages/StatusConfigSet.h
+++ b/include/seatrac_driver/messages/StatusConfigSet.h
@@ -22,9 +22,7 @@ struct StatusConfigSet : public Message<StatusConfigSet>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::StatusConfigSet& msg)
@@ -33,6 +31,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "StatusConfigSet : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_STATUSCONFIGSET_H_
 

--- a/include/seatrac_driver/messages/SysAlive.h
+++ b/include/seatrac_driver/messages/SysAlive.h
@@ -16,9 +16,7 @@ struct SysAlive : public Message<SysAlive>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SysAlive& msg)
@@ -29,6 +27,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "alivedFor    : " << (uint32_t)msg.alivedFor;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SYSALIVE_H_
 

--- a/include/seatrac_driver/messages/SysInfo.h
+++ b/include/seatrac_driver/messages/SysInfo.h
@@ -22,9 +22,7 @@ struct SysInfo : public Message<SysInfo>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SysInfo& msg)
@@ -41,5 +39,9 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "boardRev     : " << (uint32_t)msg.boardRev;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SYSINFO_H_

--- a/include/seatrac_driver/messages/SysReboot.h
+++ b/include/seatrac_driver/messages/SysReboot.h
@@ -23,9 +23,7 @@ struct SysReboot : public Message<SysReboot>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::SysReboot& msg)
@@ -36,6 +34,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "status : " << (uint32_t)msg.status;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_SYSREBOOT_H_
 

--- a/include/seatrac_driver/messages/XcvrAnalyse.h
+++ b/include/seatrac_driver/messages/XcvrAnalyse.h
@@ -25,9 +25,7 @@ struct XcvrAnalyse : public Message<XcvrAnalyse>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::XcvrAnalyse& msg)
@@ -43,6 +41,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "rxLevelRMS  : " << msg.rxLevelRMS;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_XCVR_ANALYSE_h_
 

--- a/include/seatrac_driver/messages/XcvrReceptionError.h
+++ b/include/seatrac_driver/messages/XcvrReceptionError.h
@@ -25,9 +25,7 @@ struct XcvrReceptionError : public Message<XcvrReceptionError>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::XcvrReceptionError& msg)
@@ -38,6 +36,10 @@ inline std::ostream& operator<<(std::ostream& os,
        << prefix << "acousticFix : " << print_utils::indent(msg.acousticFix);
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_XCVR_RECEPTION_ERROR_h_
 

--- a/include/seatrac_driver/messages/XcvrStatus.h
+++ b/include/seatrac_driver/messages/XcvrStatus.h
@@ -19,9 +19,7 @@ struct XcvrStatus : public Message<XcvrStatus>
 }__attribute__((packed));
 
 
-}; //namespace messages
-}; //namespace seatrac
-}; //namespace narval
+
 
 inline std::ostream& operator<<(std::ostream& os,
                                 const narval::seatrac::messages::XcvrStatus& msg)
@@ -29,6 +27,10 @@ inline std::ostream& operator<<(std::ostream& os,
     os << "XcvrStatus : " << msg.statusCode;
     return os;
 }
+
+}; //namespace messages
+}; //namespace seatrac
+}; //namespace narval
 
 #endif //_DEF_SEATRAC_DRIVER_MESSAGES_XCVR_STATUS_h_
 


### PR DESCRIPTION
Braden and I were working with the seartrac-ros2 and seatrac-driver code today and ran into some pretty gnarly errors when trying to build seatrac-ros2 (which then pulls in this repo) using colcon build in both ROS 2 Jazzy and ROS 2 Humble. Changing the location of the closing namespacing brackets like this fixed the error for us, and we could receive and transmit data normally using the modems once it built.

We're not the most familiar with this code, so @ClaytonSmith314 would you be willing to look over and approve the changes? Have you run into the same error before?